### PR TITLE
Add minimal Hello World PWA

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
-# codex-playground
+# Hello World PWA
+
+This repository contains a minimal Progressive Web App (PWA) that displays a simple "Hello, World!" message. It can be installed on mobile devices such as an iPhone.
+
+## Running Locally
+
+1. Make sure you have a static file server installed. If you have Python, you can run:
+
+   ```bash
+   python3 -m http.server 8080
+   ```
+
+2. Open `http://localhost:8080` in your browser. On supported mobile browsers you should be prompted to install the app.
+
+The PWA consists of:
+
+- `index.html` – main page registering the service worker.
+- `manifest.json` – PWA manifest with inline SVG icon and display settings.
+- `service-worker.js` – simple cache-first service worker.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="manifest" href="manifest.json">
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="default">
+  <meta name="apple-mobile-web-app-title" content="Hello PWA">
+  <title>Hello PWA</title>
+</head>
+<body>
+  <h1>Hello, World!</h1>
+  <script>
+    if ('serviceWorker' in navigator) {
+      window.addEventListener('load', function() {
+        navigator.serviceWorker.register('/service-worker.js');
+      });
+    }
+  </script>
+</body>
+</html>

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,20 @@
+{
+  "name": "Hello PWA",
+  "short_name": "Hello",
+  "start_url": ".",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#000000",
+  "icons": [
+    {
+      "src": "data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A//www.w3.org/2000/svg%27%20viewBox%3D%270%200%20100%20100%27%3E%3Crect%20width%3D%27100%27%20height%3D%27100%27%20fill%3D%27%23007aff%27/%3E%3Ctext%20x%3D%2750%27%20y%3D%2760%27%20font-size%3D%2760%27%20text-anchor%3D%27middle%27%20fill%3D%27white%27%3EH%3C/text%3E%3C/svg%3E",
+      "sizes": "192x192",
+      "type": "image/svg+xml"
+    },
+    {
+      "src": "data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A//www.w3.org/2000/svg%27%20viewBox%3D%270%200%20100%20100%27%3E%3Crect%20width%3D%27100%27%20height%3D%27100%27%20fill%3D%27%23007aff%27/%3E%3Ctext%20x%3D%2750%27%20y%3D%2760%27%20font-size%3D%2760%27%20text-anchor%3D%27middle%27%20fill%3D%27white%27%3EH%3C/text%3E%3C/svg%3E",
+      "sizes": "512x512",
+      "type": "image/svg+xml"
+    }
+  ]
+}

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,0 +1,19 @@
+self.addEventListener('install', function(event) {
+  event.waitUntil(
+    caches.open('hellopwa').then(function(cache) {
+      return cache.addAll([
+        '/',
+        '/index.html',
+        '/manifest.json'
+      ]);
+    })
+  );
+});
+
+self.addEventListener('fetch', function(event) {
+  event.respondWith(
+    caches.match(event.request).then(function(response) {
+      return response || fetch(event.request);
+    })
+  );
+});


### PR DESCRIPTION
## Summary
- implement minimal PWA with service worker and manifest
- embed SVG icon directly in manifest and remove binary files
- document how to run the app locally

## Testing
- `python3 -m http.server 8080`


------
https://chatgpt.com/codex/tasks/task_e_6884dcf584a083298c4f72c62c3a90c5