### PR TITLE
docs: expand PWA setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,18 +2,48 @@
 
 This repository contains a minimal Progressive Web App (PWA) that displays a simple "Hello, World!" message. It can be installed on mobile devices such as an iPhone.
 
+## Prerequisites
+
+- [Python 3](https://www.python.org/) **or** [Node.js](https://nodejs.org/)
+- A modern browser with PWA support (Chrome, Edge, Safari on iOS 16+, etc.)
+
 ## Running Locally
 
-1. Make sure you have a static file server installed. If you have Python, you can run:
+1. Clone this repository and change into the project directory:
 
    ```bash
-   python3 -m http.server 8080
+   git clone <repository-url>
+   cd codex-playground
    ```
 
-2. Open `http://localhost:8080` in your browser. On supported mobile browsers you should be prompted to install the app.
+2. Start a static file server. Choose one of the following options:
+
+   - **Python 3**
+
+     ```bash
+     python3 -m http.server 8080
+     ```
+
+   - **Node.js** (requires the `serve` package, install with `npm install -g serve`)
+
+     ```bash
+     npx serve -l 8080
+     ```
+
+   Leave the terminal running while you test the app. Press `Ctrl+C` to stop the server when you're done.
+
+3. Open a browser and navigate to `http://localhost:8080/`. You should see "Hello, World!" on the page.
+
+## Installing the PWA
+
+1. **Desktop (Chrome/Edge)** – Look for the install icon in the address bar or open the browser menu and choose **Install**.
+2. **iOS Safari** – Tap the **Share** button and select **Add to Home Screen**.
+3. Launch the installed app from your home screen. It will open in a standalone window and work offline.
+
+## Project Structure
 
 The PWA consists of:
 
-- `index.html` – main page registering the service worker.
-- `manifest.json` – PWA manifest with inline SVG icon and display settings.
+- `index.html` – registers the service worker.
+- `manifest.json` – PWA manifest containing app metadata and icon.
 - `service-worker.js` – simple cache-first service worker.


### PR DESCRIPTION
## Summary
- clarify prerequisites for running the PWA
- add step-by-step server setup and installation guidance

## Testing
- `python3 -m http.server 8080 & curl -I http://localhost:8080/index.html`


------
https://chatgpt.com/codex/tasks/task_e_68bdd2e97f008329869438457adc5e0b